### PR TITLE
Avoid possible crash in Python3

### DIFF
--- a/dpkg-scanpackages.py
+++ b/dpkg-scanpackages.py
@@ -164,7 +164,7 @@ def main():
             output=args.output
         ).scan()
     except ValueError as err:
-        print_error(err.message)
+        print_error(str(err))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
I found myself using this script, but there's this small issue where `.message` does not exist in python3. This will cause an `AttributeError` when the `ValueError` is caught.